### PR TITLE
Corregido select para edición de usuario

### DIFF
--- a/src/views/apps/student/store/index.js
+++ b/src/views/apps/student/store/index.js
@@ -104,7 +104,10 @@ export const updateUser = createAsyncThunk(
   "appUsers/updateUser",
   async (updatedUser) => {
     await updateUserBy(updatedUser)
-      .then((e) => toast.success("Datos Guardados"))
+      .then((response) => {
+        updatedUser = response.data.user
+        toast.success("Datos Guardados")
+      })
       .catch((e) => {
         toast.error("Error al editar");
       });

--- a/src/views/apps/student/view/UserInfoCard.js
+++ b/src/views/apps/student/view/UserInfoCard.js
@@ -336,8 +336,8 @@ const UserInfoCard = ({ id }) => {
                 </Label>
                 <Controller
                   defaultValue={{
-                    label: selectedUser.cycle_name,
-                    value: selectedUser.cycle.value,
+                    label: selectedUser.cycle_info.long_name,
+                    value: selectedUser.cycle_info.id,
                   }} // Set the default value to the first option in the array
                   control={control}
                   id="cycle"


### PR DESCRIPTION
Modificación en el seleccionable de la vista edición de usuario, para que obtenga el ciclo del usuario desde la store, también se ha realizado una modificación en el asyncTunk que llama a la api para editar el usuario, en la que si el endpoint responde con OK, obtenemos el usuario devuelto por el endpoint y lo seteamos en la store.