### PR TITLE
Corrección en ficha de cliente, no mostraba el ciclo a veces.

### DIFF
--- a/src/views/apps/student/view/UserInfoCard.js
+++ b/src/views/apps/student/view/UserInfoCard.js
@@ -226,7 +226,7 @@ const UserInfoCard = ({ id }) => {
                 <li className="mb-75">
                   <span className="fw-bolder me-25">Ciclo: </span>
                   <span>
-                    {cycleOptions[selectedUser.cycle - 1].label}
+                    {cycleOptions.find(cycleOption => cycleOption.value === selectedUser.cycle)?.label}
                   </span>
                 </li>
               </ul>


### PR DESCRIPTION
Corrección en la forma de obtener el label del ciclo del estudiante, la anterior no era consistente y a parte de no mostrar el ciclo cuando había saltos en el array, dejaba la página en blanco al no controlar los casos en los que no exista la propiedad "label"